### PR TITLE
Fix: When inserting an average fact, don't call keyword on the :id

### DIFF
--- a/src/time_series_storage/postgres/update.clj
+++ b/src/time_series_storage/postgres/update.clj
@@ -64,7 +64,7 @@
           (for [group (:grouped_by dimension)]
             (let [table-name (->> (conj group (:id dimension))
                                   (make-table-name fact))
-                  value (get event (keyword (:id fact)))]
+                  value (get event (:id fact))]
               (when-let [key (event-key fact dimension group event date-time)]
                 (with [:upsert (update table-name (conj '()
                                                         '(= counter counter+1)


### PR DESCRIPTION
It should do the same as a counter fact, which doesn't call keyword. In fact,
we should refactor this code a bit, because counter & average have a lot in
common