### PR TITLE
Remove :aot :all

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,6 @@
   :url "https://github.com/guilespi/time-series-storage"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :aot :all
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [org.clojure/java.jdbc "0.3.5"]
                  [postgresql/postgresql "8.4-702.jdbc4"]


### PR DESCRIPTION
I'm not sure in which case would this be needed, but when present it makes it difficult to update
dependencies for a project using this library (I had issues updating sqlingvo for example)